### PR TITLE
This commit changes the create and tidy scripts to:

### DIFF
--- a/files/create-metrics-archive
+++ b/files/create-metrics-archive
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 while [[ $1 ]]; do
-   case "$1" in
-      '-d'|'--directory')
-         metrics_dir="$2"
-         ;;
-      '-r'|'--retention-days')
-         ret_days="$2"
-   esac
-   shift 2
+  case "$1" in
+    '-d'|'--directory')
+      metrics_dir="$2"
+      ;;
+    '-r'|'--retention-days')
+      ret_days="$2"
+  esac
+  shift 2
 done
 
 # Arguments and defaults.
@@ -18,6 +18,6 @@ timestamp="$(date +%Y.%m.%d.%H.%M.%S)"
 output_file="puppet-metrics-collector-${timestamp}.tar.gz"
 
 find "$metrics_dir" -type f -ctime -"$ret_days" -a \( -name "*json" -o -name "*gz" \) | \
-   tar czf "$output_file" --transform "s,^${metrics_dir#/},puppet-metrics-${timestamp}," --files-from - || exit 1
+  tar czf "$output_file" --transform "s,^${metrics_dir#/},puppet-metrics-${timestamp}," --files-from - || exit 1
 
 echo "Created metrics archive: $output_file"

--- a/files/create-metrics-archive
+++ b/files/create-metrics-archive
@@ -6,7 +6,7 @@ set -e
 
 while [[ $1 ]]; do
   case "$1" in
-    '-m'|'--metrics-directory')
+    '-m'|'--metrics-dir')
       arg_metrics_dir="$2"
       ;;
     '-r'|'--retention-days')

--- a/files/create-metrics-archive
+++ b/files/create-metrics-archive
@@ -6,7 +6,7 @@ set -e
 
 while [[ $1 ]]; do
   case "$1" in
-    '-m'|'--metrics-dir')
+    '-m'|'--metrics-directory')
       arg_metrics_dir="$2"
       ;;
     '-r'|'--retention-days')

--- a/files/create-metrics-archive
+++ b/files/create-metrics-archive
@@ -2,7 +2,7 @@
 
 while [[ $1 ]]; do
    case "$1" in
-      '-m'|'--metrics-dir')
+      '-d'|'--directory')
          metrics_dir="$2"
          ;;
       '-r'|'--retention-days')

--- a/files/create-metrics-archive
+++ b/files/create-metrics-archive
@@ -14,9 +14,10 @@ done
 # Arguments and defaults.
 metrics_dir="${metrics_dir:-/opt/puppetlabs/puppet-metrics-collector}"
 ret_days="${ret_days:-30}"
-output_file="puppet-metrics-collector-$(date +%Y.%m.%d.%H.%M.%S).tar.gz"
+timestamp="$(date +%Y.%m.%d.%H.%M.%S)"
+output_file="puppet-metrics-collector-${timestamp}.tar.gz"
 
 find "$metrics_dir" -type f -ctime -"$ret_days" -a \( -name "*json" -o -name "*gz" \) | \
-   tar czf "$output_file" --transform "s,^${metrics_dir#/},puppet-metrics," --files-from - || exit 1
+   tar czf "$output_file" --transform "s,^${metrics_dir#/},puppet-metrics-${timestamp}," --files-from - || exit 1
 
 echo "Created metrics archive: $output_file"

--- a/files/create-metrics-archive
+++ b/files/create-metrics-archive
@@ -1,29 +1,22 @@
 #!/bin/bash
 
-set -e
-
-# Arguments and defaults.
-
 while [[ $1 ]]; do
-  case "$1" in
-    '-m'|'--metrics-directory')
-      arg_metrics_dir="$2"
-      ;;
-    '-r'|'--retention-days')
-    arg_retention_days="$2"
-  esac
-  shift 2
+   case "$1" in
+      '-m'|'--metrics-dir')
+         metrics_dir="$2"
+         ;;
+      '-r'|'--retention-days')
+         ret_days="$2"
+   esac
+   shift 2
 done
 
-METRICS_OUTPUT_DIR=${arg_metrics_dir:-/opt/puppetlabs/puppet-metrics-collector}
-RETENTION_DAYS=${arg_retention_days:-30}
+# Arguments and defaults.
+metrics_dir="${metrics_dir:-/opt/puppetlabs/puppet-metrics-collector}"
+ret_days="${ret_days:-30}"
+output_file="puppet-metrics-collector-$(date +%Y.%m.%d.%H.%M.%S).tar.gz"
 
-DATETIME=$(date +%Y.%m.%d.%H.%M.%S)
-OUTPUT_FILE="$(pwd)/puppet-metrics-$DATETIME.tar.gz"
+find "$metrics_dir" -type f -ctime -"$ret_days" -a \( -name "*json" -o -name "*gz" \) | \
+   tar czf "$output_file" --transform "s,^${metrics_dir#/},puppet-metrics," --files-from - || exit 1
 
-cd "$METRICS_OUTPUT_DIR"
-find . -type f -ctime -"$RETENTION_DAYS" -regex '\(.*gz$\|.*json$\)' > "$METRICS_OUTPUT_DIR.tmp"
-tar --create --gzip --file "$OUTPUT_FILE" --files-from "$METRICS_OUTPUT_DIR.tmp" --transform "s,^,/puppet-metrics-$DATETIME/,"
-rm "$METRICS_OUTPUT_DIR.tmp"
-
-echo "Created metrics archive: ${OUTPUT_FILE}"
+echo "Created metrics archive: $output_file"

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -9,12 +9,21 @@ RETENTION_DAYS=${2:-90}
 
 METRICS_TYPE=$(basename "$METRICS_DIR")
 
-# Guard. 
+# Guard against deleting or archiving other files. 
 
 INVALID_PATHS=(/ /etc /var /opt /usr)
 METRICS_REALPATH=$(realpath "$METRICS_DIR")
-if [ "$METRICS_REALPATH" = "/" ]; then
-  echo "Invalid options"
+
+for INVALID_PATH in "${INVALID_PATHS[@]}"
+do
+  if [ " $METRICS_REALPATH " = " $INVALID_PATH " ]; then
+    echo "Invalid metrics directory"
+    exit 1
+  fi
+done
+
+if [ " $METRICS_TYPE " = " puppet-metrics-collector " ]; then
+  echo "Invalid metrics directory"
   exit 1
 fi
 
@@ -28,7 +37,7 @@ cd "$METRICS_DIR"
 find . -type f -name "*.json" > "$METRICS_DIR.tmp"
 tar --create --gzip --file "$METRICS_DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.gz" --files-from "$METRICS_DIR.tmp"
 
-# Delete the files that have been compressed.
+# Delete metrics files that have been archived.
 
 xargs -r -a "$METRICS_DIR.tmp" rm
 rm "$METRICS_DIR.tmp"

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -2,7 +2,7 @@
 
 while [[ $1 ]]; do
    case "$1" in
-      '-m'|'--metrics-dir')
+      '-d'|'--directory')
          metrics_dir="$2"
          ;;
       '-r'|'--retention-days')
@@ -14,9 +14,10 @@ done
 # Arguments and defaults.
 metrics_dir="${metrics_dir:-/opt/puppetlabs/puppet-metrics-collector/puppetserver}"
 ret_days="${ret_days:-90}"
+# Parameter expansion to strip everything before the last '/', giving us the basename
 metrics_type="${metrics_dir##*/}"
 
-# Guard against deleting or archiving other files. 
+# Guard against deleting or archiving other files.
 valid_paths=(puppetserver puppetdb orchestrator ace bolt activemq)
 paths_regex="$(IFS='|'; echo "${valid_paths[*]}")"
 

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -9,21 +9,12 @@ RETENTION_DAYS=${2:-90}
 
 METRICS_TYPE=$(basename "$METRICS_DIR")
 
-# Guard against deleting or archiving other files. 
+# Guard. 
 
 INVALID_PATHS=(/ /etc /var /opt /usr)
 METRICS_REALPATH=$(realpath "$METRICS_DIR")
-
-for INVALID_PATH in "${INVALID_PATHS[@]}"
-do
-  if [ " $METRICS_REALPATH " = " $INVALID_PATH " ]; then
-    echo "Invalid metrics directory"
-    exit 1
-  fi
-done
-
-if [ " $METRICS_TYPE " = " puppet-metrics-collector " ]; then
-  echo "Invalid metrics directory"
+if [ "$METRICS_REALPATH" = "/" ]; then
+  echo "Invalid options"
   exit 1
 fi
 
@@ -37,7 +28,7 @@ cd "$METRICS_DIR"
 find . -type f -name "*.json" > "$METRICS_DIR.tmp"
 tar --create --gzip --file "$METRICS_DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.gz" --files-from "$METRICS_DIR.tmp"
 
-# Delete metrics files that have been archived.
+# Delete the files that have been compressed.
 
 xargs -r -a "$METRICS_DIR.tmp" rm
 rm "$METRICS_DIR.tmp"

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -1,43 +1,33 @@
 #!/bin/bash
 
-set -e
-
-# Arguments and defaults.
-
-METRICS_DIR=${1:-/opt/puppetlabs/puppet-metrics-collector/puppetserver}
-RETENTION_DAYS=${2:-90}
-
-METRICS_TYPE=$(basename "$METRICS_DIR")
-
-# Guard against deleting or archiving other files. 
-
-INVALID_PATHS=(/ /etc /var /opt /usr)
-METRICS_REALPATH=$(realpath "$METRICS_DIR")
-
-for INVALID_PATH in "${INVALID_PATHS[@]}"
-do
-  if [ " $METRICS_REALPATH " = " $INVALID_PATH " ]; then
-    echo "Invalid metrics directory"
-    exit 1
-  fi
+while [[ $1 ]]; do
+   case "$1" in
+      '-m'|'--metrics-dir')
+         metrics_dir="$2"
+         ;;
+      '-r'|'--retention-days')
+         ret_days="$2"
+   esac
+   shift 2
 done
 
-if [ " $METRICS_TYPE " = " puppet-metrics-collector " ]; then
-  echo "Invalid metrics directory"
-  exit 1
-fi
+# Arguments and defaults.
+metrics_dir="${metrics_dir:-/opt/puppetlabs/puppet-metrics-collector/puppetserver}"
+ret_days="${ret_days:-90}"
+metrics_type="${metrics_dir##*/}"
 
-# Delete metrics files older than the retention period, in days.
+# Guard against deleting or archiving other files. 
+valid_paths=(puppetserver puppetdb orchestrator ace bolt activemq)
+paths_regex="$(IFS='|'; echo "${valid_paths[*]}")"
 
-find "$METRICS_DIR" -type f -ctime +"$RETENTION_DAYS" -regex '\(.*gz$\|.*json$\)' -delete
+# Check that the directory ends in one of the Puppet services we collect metrics for
+[[ $metrics_dir =~ ${paths_regex}$ ]] || {
+   echo "Invalid metrics path.  Must end in one of: $(echo -n "${valid_paths[@]}")."
+   exit 1
+}
 
-# Archive the remaining metrics files.
+# Delete files older than the retention period, in days.
+find "$metrics_dir" -type f -ctime +"$ret_days" -delete
 
-cd "$METRICS_DIR"
-find . -type f -name "*.json" > "$METRICS_DIR.tmp"
-tar --create --gzip --file "$METRICS_DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.gz" --files-from "$METRICS_DIR.tmp"
-
-# Delete metrics files that have been archived.
-
-xargs -r -a "$METRICS_DIR.tmp" rm
-rm "$METRICS_DIR.tmp"
+# Compress the remaining files.
+find "$metrics_dir" -type f -name "*json" | tar zcf "${metrics_dir}/${metrics_type}-$(date +%Y.%m.%d.%H.%M.%S).tar.gz" --files-from -

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 while [[ $1 ]]; do
-   case "$1" in
-      '-d'|'--directory')
-         metrics_dir="$2"
-         ;;
-      '-r'|'--retention-days')
-         ret_days="$2"
-   esac
-   shift 2
+  case "$1" in
+    '-d'|'--directory')
+      metrics_dir="$2"
+      ;;
+    '-r'|'--retention-days')
+      ret_days="$2"
+  esac
+  shift 2
 done
 
 # Arguments and defaults.
@@ -23,8 +23,8 @@ paths_regex="$(IFS='|'; echo "${valid_paths[*]}")"
 
 # Check that the directory ends in one of the Puppet services we collect metrics for
 [[ $metrics_dir =~ ${paths_regex}$ ]] || {
-   echo "Invalid metrics path.  Must end in one of: $(echo -n "${valid_paths[@]}")."
-   exit 1
+  echo "Invalid metrics path.  Must end in one of: $(echo -n "${valid_paths[@]}")."
+  exit 1
 }
 
 # Delete files older than the retention period, in days.

--- a/files/pe_metrics.rb
+++ b/files/pe_metrics.rb
@@ -47,7 +47,7 @@ ADDITIONAL_METRICS = config['additional_metrics']
 # Metrics endpoints for our Trapper Keeper services do not require a client certificate.
 
 if USE_CLIENTCERT
-  SSLDIR = `/opt/puppetlabs/bin/puppet config print ssldir`.chomp
+  SSLDIR = `/usr/local/bin/puppet config print ssldir`.chomp
 end
 
 $error_array = []

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -96,7 +96,7 @@ define puppet_metrics_collector::pe_metric (
 
   cron { "${metrics_type}_metrics_tidy" :
     ensure  => $metric_ensure,
-    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy ${metrics_output_dir} ${retention_days}",
+    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy -m ${metrics_output_dir} -r ${retention_days}",
     user    => 'root',
     hour    => fqdn_rand(3, $metrics_type),
     minute  => (5 * fqdn_rand(11, $metrics_type)),

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -93,10 +93,11 @@ define puppet_metrics_collector::pe_metric (
 
   # The hardcoded numbers with the fqdn_rand calls are to trigger the metrics_tidy
   # command to run at a randomly selected time between 12:00 AM and 3:00 AM.
+  # NOTE - if adding a new service, the name of the service must be added to the valid_paths array in files/metrics_tidy
 
   cron { "${metrics_type}_metrics_tidy" :
     ensure  => $metric_ensure,
-    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy -m ${metrics_output_dir} -r ${retention_days}",
+    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy -d ${metrics_output_dir} -r ${retention_days}",
     user    => 'root',
     hour    => fqdn_rand(3, $metrics_type),
     minute  => (5 * fqdn_rand(11, $metrics_type)),

--- a/manifests/sar_metric.pp
+++ b/manifests/sar_metric.pp
@@ -42,7 +42,7 @@ define puppet_metrics_collector::sar_metric (
 
   cron { "${metrics_type}_metrics_tidy" :
     ensure  => $metric_ensure,
-    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy ${metrics_output_dir} ${retention_days}",
+    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy -m ${metrics_output_dir} -r ${retention_days}",
     user    => 'root',
     hour    => fqdn_rand(3, $metrics_type),
     minute  => (5 * fqdn_rand(11, $metrics_type)),

--- a/manifests/sar_metric.pp
+++ b/manifests/sar_metric.pp
@@ -39,10 +39,11 @@ define puppet_metrics_collector::sar_metric (
 
   # The hardcoded numbers with the fqdn_rand calls are to trigger the metrics_tidy 
   # command to run at a randomly selected time between 12:00 AM and 3:00 AM.
+  # NOTE - if adding a new service, the name of the service must be added to the valid_paths array in files/metrics_tidy
 
   cron { "${metrics_type}_metrics_tidy" :
     ensure  => $metric_ensure,
-    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy -m ${metrics_output_dir} -r ${retention_days}",
+    command => "${puppet_metrics_collector::scripts_dir}/metrics_tidy -d ${metrics_output_dir} -r ${retention_days}",
     user    => 'root',
     hour    => fqdn_rand(3, $metrics_type),
     minute  => (5 * fqdn_rand(11, $metrics_type)),


### PR DESCRIPTION
* Accept arguments instead of positional parameters in metrics_tidy
* Pipe the results of find to tar directly
* Changes path validation to ensure the target directory ends in one of
  the services we collect metrics for
* Use lowercase variables to we're not being yelled at